### PR TITLE
make navbar fixed to top upon scroll

### DIFF
--- a/src/components/Navigation/NavBar/NavBar.js
+++ b/src/components/Navigation/NavBar/NavBar.js
@@ -54,7 +54,7 @@ function CreateNavBar(props) {
 
   return (
     <div className={classes.navBarRoot}>
-      <AppBar position="static" className={classes.appBar}>
+      <AppBar position="fixed" className={classes.appBar}>
         <Toolbar>
           <IconButton
             edge="start"
@@ -69,6 +69,7 @@ function CreateNavBar(props) {
           <ActionItems isLoggedIn={props.isLoggedIn} />
         </Toolbar>
       </AppBar>
+      <Toolbar />
     </div>
   );
 }


### PR DESCRIPTION
Mostly doing this so the notifications menu dont just float on the page dangling while the user scrolls the page with their notifications menu opened. It also just looks nice to have the navbar always in sight as you scroll to bottom.
Learned the trick from [here](https://material-ui.com/components/app-bar/#fixed-placement)