### PR TITLE
fix handle close confirmation dialog bug

### DIFF
--- a/src/components/ConfirmationDialog.js
+++ b/src/components/ConfirmationDialog.js
@@ -7,29 +7,25 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogContentText from "@material-ui/core/DialogContentText";
 
 class ConfirmationDialog extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      isOpen: props.open,
-    };
-  }
-
-  handleConfirmationClose = () => {
-    this.setState({ isOpen: false });
-  };
-
   render() {
-    const { submitAction, submitName, dialogMessage, dialogTitle } = this.props;
+    const {
+      open,
+      submitAction,
+      submitName,
+      dialogMessage,
+      dialogTitle,
+      handleClose,
+    } = this.props;
 
     return (
-      <Dialog open={this.state.isOpen} onClose={this.handleConfirmationClose}>
+      <Dialog open={open} onClose={handleClose}>
         <DialogTitle id="alert-dialog-title">{dialogTitle}</DialogTitle>
         <DialogContent>
           <DialogContentText id="alert-dialog-description">
             {dialogMessage}
           </DialogContentText>
           <DialogActions>
-            <Button onClick={this.handleConfirmationClose} color="primary">
+            <Button onClick={handleClose} color="primary">
               Cancel
             </Button>
             <Button onClick={submitAction} color="primary">

--- a/src/components/pages/EditItemDetailsPage.js
+++ b/src/components/pages/EditItemDetailsPage.js
@@ -187,6 +187,7 @@ class EditItemDetailsPage extends React.Component {
             submitName={"Delete"}
             dialogMessage={"This action cannot be undone"}
             dialogTitle={"Are you sure you want to delete this posting?"}
+            handleClose={this.handleConfirmationClose}
           />
         );
       default:
@@ -197,6 +198,7 @@ class EditItemDetailsPage extends React.Component {
             submitName={"OK"}
             dialogMessage={"Any changes will not be saved"}
             dialogTitle={"Are you sure you want to leave this page?"}
+            handleClose={this.handleConfirmationClose}
           />
         );
     }


### PR DESCRIPTION
Bug: if you cancel/dismiss a confirmation dialog, then attempt to trigger the confirmation again, the dialog box would not open because not properly resetting the isOpen state in the original calling component.