### PR TITLE
User profile offers: Preview Cards & Accept/Decline

### DIFF
--- a/src/components/AddOffering/AddOffering.js
+++ b/src/components/AddOffering/AddOffering.js
@@ -12,7 +12,7 @@ import {
   displayError,
   displaySuccess,
 } from "../../redux/actions/snackbarActions";
-import { ADD_OFFER_MISSING_INFO_ERROR } from "../../redux/constants/snackbarMessageTypes";
+import { ADD_OFFER_MISSING_INFO_ERROR, MAKE_OFFER_SUCCESS } from "../../redux/constants/snackbarMessageTypes";
 
 const useStyles = (theme) => ({
   paper: {
@@ -178,15 +178,13 @@ class AddOffering extends React.Component {
 
       let id = this.props.itemDetail._id;
       this.props.makeOffer(offering, id);
-      this.props.displaySuccess("Offer successfully made");
+      this.props.displaySuccess(MAKE_OFFER_SUCCESS);
       this.resetFormState();
       setTimeout(() => {
         this.props.closeModal();
       }, 700);
     } else {
-      this.props.displayError(
-        "An offer must have either must have either a comment or an item"
-      );
+      this.props.displayError(ADD_OFFER_MISSING_INFO_ERROR);
     }
   };
 

--- a/src/components/AddOffering/AddOffering.js
+++ b/src/components/AddOffering/AddOffering.js
@@ -12,7 +12,7 @@ import {
   displayError,
   displaySuccess,
 } from "../../redux/actions/snackbarActions";
-import { ADD_OFFER_MISSING_INFO_ERROR, MAKE_OFFER_SUCCESS } from "../../redux/constants/snackbarMessageTypes";
+import { ADD_OFFER_MISSING_INFO_ERROR } from "../../redux/constants/snackbarMessageTypes";
 
 const useStyles = (theme) => ({
   paper: {
@@ -178,7 +178,6 @@ class AddOffering extends React.Component {
 
       let id = this.props.itemDetail._id;
       this.props.makeOffer(offering, id);
-      this.props.displaySuccess(MAKE_OFFER_SUCCESS);
       this.resetFormState();
       setTimeout(() => {
         this.props.closeModal();

--- a/src/components/AddOffering/AddOffering.js
+++ b/src/components/AddOffering/AddOffering.js
@@ -178,12 +178,15 @@ class AddOffering extends React.Component {
 
       let id = this.props.itemDetail._id;
       this.props.makeOffer(offering, id);
+      this.props.displaySuccess("Offer successfully made");
       this.resetFormState();
       setTimeout(() => {
         this.props.closeModal();
       }, 700);
     } else {
-      this.props.displayError(ADD_OFFER_MISSING_INFO_ERROR);
+      this.props.displayError(
+        "An offer must have either must have either a comment or an item"
+      );
     }
   };
 

--- a/src/components/HigherOrderComponents/HoverPopoverHOC.js
+++ b/src/components/HigherOrderComponents/HoverPopoverHOC.js
@@ -10,6 +10,8 @@ const useStyles = makeStyles((theme) => ({
   },
   paper: {
     padding: theme.spacing(1),
+    background: "rgba(5, 5, 5, 0.7)",
+    color: "white",
   },
 }));
 

--- a/src/components/HigherOrderComponents/HoverPopoverHOC.js
+++ b/src/components/HigherOrderComponents/HoverPopoverHOC.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import Popover from '@material-ui/core/Popover';
+import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+
+
+const useStyles = makeStyles((theme) => ({
+  popover: {
+    pointerEvents: 'none',
+  },
+  paper: {
+    padding: theme.spacing(1),
+  },
+}));
+
+export const HoverPopoverHOC = (hoverMessage) => (WrappedComponent) => {
+  return function HoverPopoverHOC(props) {
+    const classes = useStyles();
+    const [anchorEl, setAnchorEl] = React.useState(null);
+
+    const handlePopoverOpen = (event) => {
+      setAnchorEl(event.currentTarget);
+    };
+
+    const handlePopoverClose = () => {
+      setAnchorEl(null);
+    };
+
+    const open = Boolean(anchorEl);
+
+    return (
+      <div>
+        <WrappedComponent
+          {...props}
+          onMouseEnter={handlePopoverOpen}
+          onMouseLeave={handlePopoverClose}
+        />
+        <Popover
+          id="mouse-over-popover"
+          className={classes.popover}
+          classes={{
+            paper: classes.paper,
+          }}
+          open={open}
+          anchorEl={anchorEl}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          onClose={handlePopoverClose}
+          disableScrollLock={true}
+          disableRestoreFocus
+        >
+          <Typography>{hoverMessage}</Typography>
+        </Popover>
+      </div>
+    );
+  }
+}
+

--- a/src/components/HigherOrderComponents/HoverPopoverHOC.js
+++ b/src/components/HigherOrderComponents/HoverPopoverHOC.js
@@ -14,6 +14,12 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
+
+
+/**
+ * Code from https://material-ui.com/components/popover/#MouseOverPopover.js
+ * */
+
 export const HoverPopoverHOC = (hoverMessage) => (WrappedComponent) => {
   return function HoverPopoverHOC(props) {
     const classes = useStyles();

--- a/src/components/HigherOrderComponents/HoverPopoverHOC.js
+++ b/src/components/HigherOrderComponents/HoverPopoverHOC.js
@@ -1,12 +1,11 @@
-import React from 'react';
-import Popover from '@material-ui/core/Popover';
-import Typography from '@material-ui/core/Typography';
-import { makeStyles } from '@material-ui/core/styles';
-
+import React from "react";
+import Popover from "@material-ui/core/Popover";
+import Typography from "@material-ui/core/Typography";
+import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
   popover: {
-    pointerEvents: 'none',
+    pointerEvents: "none",
   },
   paper: {
     padding: theme.spacing(1),
@@ -46,12 +45,12 @@ export const HoverPopoverHOC = (hoverMessage) => (WrappedComponent) => {
           open={open}
           anchorEl={anchorEl}
           anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'center',
+            vertical: "bottom",
+            horizontal: "center",
           }}
           transformOrigin={{
-            vertical: 'top',
-            horizontal: 'center',
+            vertical: "top",
+            horizontal: "center",
           }}
           onClose={handlePopoverClose}
           disableScrollLock={true}
@@ -61,6 +60,5 @@ export const HoverPopoverHOC = (hoverMessage) => (WrappedComponent) => {
         </Popover>
       </div>
     );
-  }
-}
-
+  };
+};

--- a/src/components/Navigation/NavBar/ActionBtns/Notification.js
+++ b/src/components/Navigation/NavBar/ActionBtns/Notification.js
@@ -7,7 +7,6 @@ import LocalOfferIcon from "@material-ui/icons/LocalOffer";
 import Menu from "@material-ui/core/Menu";
 import MenuItem from "@material-ui/core/MenuItem";
 import moment from "moment";
-import Typography from "@material-ui/core/Typography";
 import ClearIcon from "@material-ui/icons/Clear";
 import CheckIcon from "@material-ui/icons/Check";
 import ErrorIcon from "@material-ui/icons/Error";

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import React, { useState } from "react";
+import { makeStyles } from "@material-ui/core/styles";
 import { IconButton } from "@material-ui/core";
 import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
@@ -17,20 +17,20 @@ const useStyles = makeStyles((theme) => ({
 
 function AcceptIconButton(props) {
   let classes = useStyles();
-  let {onMouseEnter, onMouseLeave, fns} = props;
+  let { onMouseEnter, onMouseLeave, fns } = props;
   let { handleConfirmationOpen } = fns;
   return (
     <React.Fragment>
-      <IconButton className={classes.acceptBtn}
-                  onMouseLeave={onMouseLeave}
-                  onMouseEnter={onMouseEnter}
-                  onClick={handleConfirmationOpen("accept")}
+      <IconButton
+        className={classes.acceptBtn}
+        onMouseLeave={onMouseLeave}
+        onMouseEnter={onMouseEnter}
+        onClick={() => handleConfirmationOpen("accept")}
       >
-        <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>
+        <CheckCircleOutlineIcon className={classes.actionBtnIcon} />
       </IconButton>
     </React.Fragment>
   );
 }
-
 
 export default HoverPopoverHOC("Accept Offer.")(AcceptIconButton);

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { IconButton } from "@material-ui/core";
+import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
+import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
+
+const useStyles = makeStyles((theme) => ({
+  acceptBtn: {
+    color: theme.palette.primary.main,
+    borderColor: theme.palette.primary.main,
+  },
+  actionBtnIcon: {
+    fontSize: "1.7rem",
+  },
+}));
+
+function AcceptIconButton(props) {
+  let classes = useStyles();
+  let {onMouseEnter, onMouseLeave} = props;
+
+  return (
+      <IconButton className={classes.acceptBtn}
+                  onMouseLeave={onMouseLeave}
+                  onMouseEnter={onMouseEnter}>
+        <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>
+      </IconButton>
+  );
+}
+
+
+export default HoverPopoverHOC("Accept Offer.")(AcceptIconButton);

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles((theme) => ({
 
 function AcceptIconButton(props) {
   let classes = useStyles();
-  let { onMouseEnter, onMouseLeave, fns, offerInfo } = props;
+  let { offerInfo, fns, onMouseEnter, onMouseLeave } = props;
   let { handleConfirmationOpen, setOfferInfoToActUpon } = fns;
   return (
     <React.Fragment>

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -26,8 +26,8 @@ function AcceptIconButton(props) {
         onMouseLeave={onMouseLeave}
         onMouseEnter={onMouseEnter}
         onClick={() => {
-          handleConfirmationOpen("accept");
           setOfferInfoToActUpon(offerInfo);
+          handleConfirmationOpen("accept");
         }}
       >
         <CheckCircleOutlineIcon className={classes.actionBtnIcon} />

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -17,15 +17,18 @@ const useStyles = makeStyles((theme) => ({
 
 function AcceptIconButton(props) {
   let classes = useStyles();
-  let { onMouseEnter, onMouseLeave, fns } = props;
-  let { handleConfirmationOpen } = fns;
+  let { onMouseEnter, onMouseLeave, fns, offerInfo } = props;
+  let { handleConfirmationOpen, setOfferInfoToActUpon } = fns;
   return (
     <React.Fragment>
       <IconButton
         className={classes.acceptBtn}
         onMouseLeave={onMouseLeave}
         onMouseEnter={onMouseEnter}
-        onClick={() => handleConfirmationOpen("accept")}
+        onClick={() => {
+          handleConfirmationOpen("accept");
+          setOfferInfoToActUpon(offerInfo);
+        }}
       >
         <CheckCircleOutlineIcon className={classes.actionBtnIcon} />
       </IconButton>

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import { IconButton } from "@material-ui/core";
 import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
-import ConfirmationDialog from "../ConfirmationDialog";
 
 const useStyles = makeStyles((theme) => ({
   acceptBtn: {
@@ -35,6 +34,5 @@ function AcceptIconButton(props) {
     </React.Fragment>
   );
 }
-
 
 export default HoverPopoverHOC("Accept Offer")(AcceptIconButton);

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -33,4 +33,5 @@ function AcceptIconButton(props) {
   );
 }
 
-export default HoverPopoverHOC("Accept Offer.")(AcceptIconButton);
+
+export default HoverPopoverHOC("Accept Offer")(AcceptIconButton);

--- a/src/components/Offering/AcceptIconButton.js
+++ b/src/components/Offering/AcceptIconButton.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { IconButton } from "@material-ui/core";
 import CheckCircleOutlineIcon from "@material-ui/icons/CheckCircleOutline";
 import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
+import ConfirmationDialog from "../ConfirmationDialog";
 
 const useStyles = makeStyles((theme) => ({
   acceptBtn: {
@@ -16,14 +17,18 @@ const useStyles = makeStyles((theme) => ({
 
 function AcceptIconButton(props) {
   let classes = useStyles();
-  let {onMouseEnter, onMouseLeave} = props;
-
+  let {onMouseEnter, onMouseLeave, fns} = props;
+  let { handleConfirmationOpen } = fns;
   return (
+    <React.Fragment>
       <IconButton className={classes.acceptBtn}
                   onMouseLeave={onMouseLeave}
-                  onMouseEnter={onMouseEnter}>
+                  onMouseEnter={onMouseEnter}
+                  onClick={handleConfirmationOpen("accept")}
+      >
         <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>
       </IconButton>
+    </React.Fragment>
   );
 }
 

--- a/src/components/Offering/DeclineIconButton.js
+++ b/src/components/Offering/DeclineIconButton.js
@@ -24,8 +24,8 @@ function DeclineIconButton(props) {
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
                 onClick={() => {
-                  handleConfirmationOpen("decline");
                   setOfferInfoToActUpon(offerInfo);
+                  handleConfirmationOpen("decline");
                 }}
     >
       <HighlightOffIcon className={classes.actionBtnIcon}/>

--- a/src/components/Offering/DeclineIconButton.js
+++ b/src/components/Offering/DeclineIconButton.js
@@ -1,27 +1,32 @@
-import React from 'react';
-import { makeStyles } from '@material-ui/core/styles';
+import React from "react";
+import { makeStyles } from "@material-ui/core/styles";
 import { IconButton } from "@material-ui/core";
 import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
 import HighlightOffIcon from "@material-ui/icons/HighlightOff";
 
 const useStyles = makeStyles(() => ({
   actionBtnIcon: {
-    fontSize: "1.7rem",
+    fontSize: "1.7rem"
   },
   declineBtn: {
     color: "#b90202",
-    borderColor: "#b90202",
-  },
+    borderColor: "#b90202"
+  }
 }));
 
 function DeclineIconButton(props) {
   let classes = useStyles();
-  let {onMouseEnter, onMouseLeave} = props;
+  let { onMouseEnter, onMouseLeave, fns, offerInfo } = props;
+  let { handleConfirmationOpen, setOfferInfoToActUpon } = fns;
 
   return (
     <IconButton className={classes.declineBtn}
                 onMouseEnter={onMouseEnter}
                 onMouseLeave={onMouseLeave}
+                onClick={() => {
+                  handleConfirmationOpen("decline");
+                  setOfferInfoToActUpon(offerInfo);
+                }}
     >
       <HighlightOffIcon className={classes.actionBtnIcon}/>
     </IconButton>

--- a/src/components/Offering/DeclineIconButton.js
+++ b/src/components/Offering/DeclineIconButton.js
@@ -6,12 +6,12 @@ import HighlightOffIcon from "@material-ui/icons/HighlightOff";
 
 const useStyles = makeStyles(() => ({
   actionBtnIcon: {
-    fontSize: "1.7rem"
+    fontSize: "1.7rem",
   },
   declineBtn: {
     color: "#b90202",
-    borderColor: "#b90202"
-  }
+    borderColor: "#b90202",
+  },
 }));
 
 function DeclineIconButton(props) {
@@ -20,18 +20,18 @@ function DeclineIconButton(props) {
   let { handleConfirmationOpen, setOfferInfoToActUpon } = fns;
 
   return (
-    <IconButton className={classes.declineBtn}
-                onMouseEnter={onMouseEnter}
-                onMouseLeave={onMouseLeave}
-                onClick={() => {
-                  setOfferInfoToActUpon(offerInfo);
-                  handleConfirmationOpen("decline");
-                }}
+    <IconButton
+      className={classes.declineBtn}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onClick={() => {
+        setOfferInfoToActUpon(offerInfo);
+        handleConfirmationOpen("decline");
+      }}
     >
-      <HighlightOffIcon className={classes.actionBtnIcon}/>
+      <HighlightOffIcon className={classes.actionBtnIcon} />
     </IconButton>
   );
 }
-
 
 export default HoverPopoverHOC("Decline Offer")(DeclineIconButton);

--- a/src/components/Offering/DeclineIconButton.js
+++ b/src/components/Offering/DeclineIconButton.js
@@ -16,7 +16,7 @@ const useStyles = makeStyles(() => ({
 
 function DeclineIconButton(props) {
   let classes = useStyles();
-  let { onMouseEnter, onMouseLeave, fns, offerInfo } = props;
+  let { offerInfo, fns, onMouseEnter, onMouseLeave } = props;
   let { handleConfirmationOpen, setOfferInfoToActUpon } = fns;
 
   return (

--- a/src/components/Offering/DeclineIconButton.js
+++ b/src/components/Offering/DeclineIconButton.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import { IconButton } from "@material-ui/core";
+import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
+import HighlightOffIcon from "@material-ui/icons/HighlightOff";
+
+const useStyles = makeStyles(() => ({
+  actionBtnIcon: {
+    fontSize: "1.7rem",
+  },
+  declineBtn: {
+    color: "#b90202",
+    borderColor: "#b90202",
+  },
+}));
+
+function DeclineIconButton(props) {
+  let classes = useStyles();
+  let {onMouseEnter, onMouseLeave} = props;
+
+  return (
+    <IconButton className={classes.declineBtn}
+                onMouseEnter={onMouseEnter}
+                onMouseLeave={onMouseLeave}
+    >
+      <HighlightOffIcon className={classes.actionBtnIcon}/>
+    </IconButton>
+  );
+}
+
+
+export default HoverPopoverHOC("Decline Offer.")(DeclineIconButton);

--- a/src/components/Offering/DeclineIconButton.js
+++ b/src/components/Offering/DeclineIconButton.js
@@ -29,4 +29,4 @@ function DeclineIconButton(props) {
 }
 
 
-export default HoverPopoverHOC("Decline Offer.")(DeclineIconButton);
+export default HoverPopoverHOC("Decline Offer")(DeclineIconButton);

--- a/src/components/Offering/OfferingHelpers.js
+++ b/src/components/Offering/OfferingHelpers.js
@@ -1,0 +1,11 @@
+import _ from "lodash";
+
+const addNumOffers = (sum, activePosting) => {
+  let numOffersForPosting = activePosting.offerings.length;
+  return sum + numOffersForPosting;
+}
+
+export const calculateTotalNumOffersReceived = (activePostings) => {
+  let sumOffersReceived = _.reduce(activePostings, addNumOffers, 0);
+  return sumOffersReceived;
+}

--- a/src/components/Offering/OfferingHelpers.js
+++ b/src/components/Offering/OfferingHelpers.js
@@ -1,11 +1,18 @@
 import _ from "lodash";
+import { offeringStatus } from "../constants/OfferingConstants";
 
 const addNumOffers = (sum, activePosting) => {
-  let numOffersForPosting = activePosting.offerings.length;
-  return sum + numOffersForPosting;
+  let pendingOffers = getAllPendingOffers(activePosting.offerings);
+  let numPendingOffersForPosting = pendingOffers.length;
+  return sum + numPendingOffersForPosting;
 }
 
-export const calculateTotalNumOffersReceived = (activePostings) => {
+export const calculateTotalPendingOffersReceived = (activePostings) => {
   let sumOffersReceived = _.reduce(activePostings, addNumOffers, 0);
   return sumOffersReceived;
+}
+
+export const getAllPendingOffers = (offerings) => {
+  let pendingOffers = _.filter(offerings, {status: offeringStatus.PENDING});
+  return pendingOffers;
 }

--- a/src/components/Offering/OfferingHelpers.js
+++ b/src/components/Offering/OfferingHelpers.js
@@ -5,14 +5,14 @@ const addNumPendingOffers = (sum, activePosting) => {
   let pendingOffers = getAllPendingOffers(activePosting.offerings);
   let numPendingOffersForPosting = pendingOffers.length;
   return sum + numPendingOffersForPosting;
-}
+};
 
 export const calculateTotalPendingOffersReceived = (activePostings) => {
   let sumOffersReceived = _.reduce(activePostings, addNumPendingOffers, 0);
   return sumOffersReceived;
-}
+};
 
 export const getAllPendingOffers = (offerings) => {
-  let pendingOffers = _.filter(offerings, {status: offeringStatus.PENDING});
+  let pendingOffers = _.filter(offerings, { status: offeringStatus.PENDING });
   return pendingOffers;
-}
+};

--- a/src/components/Offering/OfferingHelpers.js
+++ b/src/components/Offering/OfferingHelpers.js
@@ -1,14 +1,14 @@
 import _ from "lodash";
 import { offeringStatus } from "../constants/OfferingConstants";
 
-const addNumOffers = (sum, activePosting) => {
+const addNumPendingOffers = (sum, activePosting) => {
   let pendingOffers = getAllPendingOffers(activePosting.offerings);
   let numPendingOffersForPosting = pendingOffers.length;
   return sum + numPendingOffersForPosting;
 }
 
 export const calculateTotalPendingOffersReceived = (activePostings) => {
-  let sumOffersReceived = _.reduce(activePostings, addNumOffers, 0);
+  let sumOffersReceived = _.reduce(activePostings, addNumPendingOffers, 0);
   return sumOffersReceived;
 }
 

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -1,18 +1,37 @@
 import React, { useEffect, useState } from "react";
 import { getUserByIdAysnc } from "../../redux/actions/userActions";
 import { useDispatch } from "react-redux";
-import { Card, CardActionArea, CardHeader, CardMedia, CardActions } from "@material-ui/core";
+import { Card, CardActionArea, CardHeader, CardMedia, CardContent, CardActions } from "@material-ui/core";
+import { Link, Button, Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import UserAvatar from "../User/UserAvatar";
 import defaultProfile from "../../images/placeholder-profile.png";
 
 const useStyles = makeStyles(() => ({
   cardRoot: {
-    maxWidth: "350px"
+    // maxWidth: "350px"
+    minWidth: "300px",
+  },
+  cardContentRoot: {
+    "&:last-child": {
+      paddingBottom: "16px",
+    },
+  },
+  offerHeader: {
+    // padding: "10px"
+    "& .MuiCardHeader-avatar": {
+      marginRight: "10px",
+    }
+  },
+  avatar: {
+    marginRight: "10px",
   },
   previewImg: {
     height: "0",
-    paddingTop: "56.25%",
+    paddingTop: "56.25%"
+  },
+  detailsBtn: {
+    // padding: "0px",
   },
 }));
 export const OfferingPreview = (props) => {
@@ -21,7 +40,7 @@ export const OfferingPreview = (props) => {
   let classes = useStyles();
   let { offer, index } = props;
   let { offeredItems } = offer;
-  let defaultImg = require("../../images/default.jpg")
+  let defaultImg = require("../../images/default.jpg");
   let previewImg;
 
 
@@ -31,6 +50,7 @@ export const OfferingPreview = (props) => {
       setOfferer(user);
       return user;
     }
+
     getOfferer();
   }, [dispatch, offer.userId]);
 
@@ -45,26 +65,50 @@ export const OfferingPreview = (props) => {
 
   return (
     <Card elevation={2} className={classes.cardRoot}>
-      <CardActions disableSpacing>
-        <CardHeader
-          avatar={
-            <UserAvatar
-              isLargeAvatar={false}
-              userProfileImgSrc={
-                offerer.profilePic ? offerer.profilePic : defaultProfile
-              }
-            />
-          }
-          title={`${offerer.userName}`}
-          subheader={"has made you an offer"}
-        />
-      </CardActions>
+      <CardHeader
+        className={classes.offerHeader}
+        avatar={
+          <UserAvatar
+            className={classes.avatar}
+            isLargeAvatar={false}
+            userProfileImgSrc={
+              offerer.profilePic ? offerer.profilePic : defaultProfile
+            }
+          />
+        }
+        title={<Link>{`${offerer.userName}`}</Link>}
+        subheader={`has made you an offer of ${offeredItems.length} items`}
+      />
       <CardMedia
         className={classes.previewImg}
         image={previewImg}
         title="Tradeforce"
       />
 
+      <CardContent className={classes.cardContentRoot}>
+        <CardActions>
+          <Grid container item xs={12} justify={"space-between"}>
+            <Grid item xs={3}>
+            <Button >
+              Details
+            </Button>
+            </Grid>
+            <Grid container item xs={9} justify={"flex-end"}>
+              <Grid container item xs={4} justify={"flex-end"}>
+                <Button>
+                  Accept
+                </Button>
+              </Grid>
+              <Grid container item xs={4} justify={"flex-end"}>
+                <Button>
+                  Decline
+                </Button>
+              </Grid>
+            </Grid>
+          </Grid>
+        </CardActions>
+
+      </CardContent>
     </Card>
   );
 

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from "react";
+import { Card, CardActionArea, CardHeader } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
+import { getUserByIdAysnc } from "../../redux/actions/userActions";
+import { useDispatch } from "react-redux";
+import axios from "axios";
+
+const BASE_URL = `${process.env.REACT_APP_BASE_URL}`;
+
+export const OfferingPreview = (props) => {
+  let { offer, index } = props;
+  const dispatch = useDispatch();
+  const [offerer, setOfferer] = useState({ } );
+
+  useEffect( () => {
+    async function getOfferer() {
+      let user = await dispatch(getUserByIdAysnc(offer.userId));
+      setOfferer(user);
+      return user;
+    }
+    getOfferer();
+  }, [])
+
+
+  return (
+    <Card elevation={2}>
+      <CardActionArea >
+        <CardHeader title={`${offerer.userName} has made you an offer`}></CardHeader>
+      </CardActionArea>
+    </Card>
+  )
+}
+
+const mapDispatchToProps = (dispatch) => ({
+  getUser: (userId) => dispatch(getUserByIdAysnc(userId)),
+})
+

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -41,7 +41,7 @@ export const OfferingPreview = (props) => {
   const dispatch = useDispatch();
   const [offerer, setOfferer] = useState({});
   let classes = useStyles();
-  let { offer, index } = props;
+  let { offer, index, fns } = props;
   let { offeredItems } = offer;
   let defaultImg = require("../../images/default.jpg");
   let previewImg;
@@ -98,10 +98,10 @@ export const OfferingPreview = (props) => {
             </Grid>
             <Grid container item xs={8} justify={"flex-end"}>
               <Grid container item xs={4} justify={"flex-end"} >
-                <AcceptIconButton />
+                <AcceptIconButton fns={fns}/>
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <DeclineIconButton />
+                <DeclineIconButton fns={fns}/>
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -9,6 +9,8 @@ import defaultProfile from "../../images/placeholder-profile.png";
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';import CancelIcon from '@material-ui/icons/Cancel';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import AcceptIconButton from "./AcceptIconButton";
+import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
+import DeclineIconButton from "./DeclineIconButton";
 
 const useStyles = makeStyles((theme) => ({
   cardRoot: {
@@ -18,17 +20,6 @@ const useStyles = makeStyles((theme) => ({
     "&:last-child": {
       paddingBottom: "16px",
     },
-  },
-  acceptBtn: {
-    color: theme.palette.primary.main,
-    borderColor: theme.palette.primary.main,
-  },
-  actionBtnIcon: {
-    fontSize: "1.7rem",
-  },
-  declineBtn: {
-    color: "#b90202",
-    borderColor: "#b90202",
   },
   offerHeader: {
     "& .MuiCardHeader-avatar": {
@@ -107,15 +98,10 @@ export const OfferingPreview = (props) => {
             </Grid>
             <Grid container item xs={8} justify={"flex-end"}>
               <Grid container item xs={4} justify={"flex-end"} >
-                {/*<IconButton className={classes.acceptBtn}>*/}
-                {/*  <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>*/}
-                {/*</IconButton>*/}
                 <AcceptIconButton />
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <IconButton className={classes.declineBtn}>
-                  <HighlightOffIcon className={classes.actionBtnIcon}/>
-                </IconButton>
+                <DeclineIconButton />
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -95,7 +95,7 @@ export const OfferingPreview = (props) => {
             }
           />
         }
-        title={<Link>{`${offerer.userName}`}</Link>}
+        title={`${offerer.userName}`}
         subheader={`has made you an offer of ${offeredItems.length} items`}
       />
       <CardMedia

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -1,71 +1,74 @@
 import React, { useEffect, useState } from "react";
 import { getUserByIdAysnc } from "../../redux/actions/userActions";
 import { useDispatch } from "react-redux";
-import { Card, CardActionArea, CardHeader, CardMedia, CardContent, CardActions } from "@material-ui/core";
-import { Link, Button, Grid, IconButton } from "@material-ui/core";
+import { Card, CardHeader, CardMedia, CardContent, CardActions } from "@material-ui/core";
+import { Link, Button, Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import UserAvatar from "../User/UserAvatar";
 import defaultProfile from "../../images/placeholder-profile.png";
-import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';import CancelIcon from '@material-ui/icons/Cancel';
-import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 import AcceptIconButton from "./AcceptIconButton";
-import { HoverPopoverHOC } from "../HigherOrderComponents/HoverPopoverHOC";
 import DeclineIconButton from "./DeclineIconButton";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   cardRoot: {
-    minWidth: "300px",
+    minWidth: "300px"
   },
   cardContentRoot: {
     "&:last-child": {
-      paddingBottom: "16px",
-    },
+      paddingBottom: "16px"
+    }
   },
   offerHeader: {
     "& .MuiCardHeader-avatar": {
-      marginRight: "10px",
+      marginRight: "10px"
     }
   },
   avatar: {
-    marginRight: "10px",
+    marginRight: "10px"
   },
   previewImg: {
     height: "0",
     paddingTop: "56.25%"
   },
-  detailsBtn: {
-    // padding: "0px",
-  },
+  detailsBtn: {}
 }));
+
+
 export const OfferingPreview = (props) => {
   const dispatch = useDispatch();
-  const [offerer, setOfferer] = useState({});
   let classes = useStyles();
-  let { offer, index, fns } = props;
+  let { offer, fns, activePosting } = props;
   let { offeredItems } = offer;
   let defaultImg = require("../../images/default.jpg");
   let previewImg;
 
+  const [offerer, setOfferer] = useState({});
+
+  let offerInfo = {
+    offerId: offer._id,
+    offerer: offerer,
+    posting: activePosting
+  };
 
   useEffect(() => {
-    let mounted = true;
+    let isMounted = true;
 
     async function getOfferer() {
       let user = await dispatch(getUserByIdAysnc(offer.userId));
-      if (mounted) {
+      if (isMounted) {
         setOfferer(user);
         return user;
       }
     }
+
     getOfferer();
 
     return () => {
-      mounted = false;
-    }
+      isMounted = false;
+    };
   }, [dispatch, offer.userId]);
 
 
-  
   if (offeredItems.length > 0) {
     let firstItem = offeredItems[0];
     previewImg = firstItem.images.length > 0 ? firstItem.images[0] : defaultImg;
@@ -101,16 +104,17 @@ export const OfferingPreview = (props) => {
         <CardActions>
           <Grid container item xs={12} justify={"space-between"}>
             <Grid container item xs={4} alignContent={"center"}>
-              <Button >
+              <Button>
                 Details
               </Button>
             </Grid>
             <Grid container item xs={8} justify={"flex-end"}>
-              <Grid container item xs={4} justify={"flex-end"} >
-                <AcceptIconButton fns={fns}/>
+              <Grid container item xs={4} justify={"flex-end"}>
+                <AcceptIconButton fns={fns}
+                                  offerInfo={offerInfo}/>
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <DeclineIconButton fns={fns}/>
+                <DeclineIconButton fns={fns} offerInfo={offerInfo}/>
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -48,15 +48,24 @@ export const OfferingPreview = (props) => {
 
 
   useEffect(() => {
+    let mounted = true;
+
     async function getOfferer() {
       let user = await dispatch(getUserByIdAysnc(offer.userId));
-      setOfferer(user);
-      return user;
+      if (mounted) {
+        setOfferer(user);
+        return user;
+      }
     }
-
     getOfferer();
+
+    return () => {
+      mounted = false;
+    }
   }, [dispatch, offer.userId]);
 
+
+  
   if (offeredItems.length > 0) {
     let firstItem = offeredItems[0];
     previewImg = firstItem.images.length > 0 ? firstItem.images[0] : defaultImg;

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -8,6 +8,7 @@ import UserAvatar from "../User/UserAvatar";
 import defaultProfile from "../../images/placeholder-profile.png";
 import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';import CancelIcon from '@material-ui/icons/Cancel';
 import HighlightOffIcon from '@material-ui/icons/HighlightOff';
+import AcceptIconButton from "./AcceptIconButton";
 
 const useStyles = makeStyles((theme) => ({
   cardRoot: {
@@ -106,9 +107,10 @@ export const OfferingPreview = (props) => {
             </Grid>
             <Grid container item xs={8} justify={"flex-end"}>
               <Grid container item xs={4} justify={"flex-end"} >
-                <IconButton className={classes.acceptBtn}>
-                  <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>
-                </IconButton>
+                {/*<IconButton className={classes.acceptBtn}>*/}
+                {/*  <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>*/}
+                {/*</IconButton>*/}
+                <AcceptIconButton />
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
                 <IconButton className={classes.declineBtn}>

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -36,7 +36,6 @@ const useStyles = makeStyles(() => ({
     height: "0",
     paddingTop: "56.25%",
   },
-  detailsBtn: {},
 }));
 
 export const OfferingPreview = (props) => {

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -37,10 +37,9 @@ const useStyles = makeStyles(() => ({
 export const OfferingPreview = (props) => {
   const dispatch = useDispatch();
   let classes = useStyles();
+
   let { offer, fns, activePosting } = props;
   let { offeredItems } = offer;
-  let defaultImg = require("../../images/default.jpg");
-  let previewImg;
 
   const [offerer, setOfferer] = useState({});
 
@@ -49,6 +48,10 @@ export const OfferingPreview = (props) => {
     offerer: offerer,
     posting: activePosting
   };
+
+  let defaultImg = require("../../images/default.jpg");
+  let previewImg;
+
 
   useEffect(() => {
     let isMounted = true;

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { getUserByIdAysnc } from "../../redux/actions/userActions";
 import { useDispatch } from "react-redux";
-import { Card, CardHeader, CardMedia, CardContent, CardActions } from "@material-ui/core";
+import {
+  Card,
+  CardHeader,
+  CardMedia,
+  CardContent,
+  CardActions,
+} from "@material-ui/core";
 import { Link, Button, Grid } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import UserAvatar from "../User/UserAvatar";
@@ -11,28 +17,27 @@ import DeclineIconButton from "./DeclineIconButton";
 
 const useStyles = makeStyles(() => ({
   cardRoot: {
-    minWidth: "300px"
+    minWidth: "300px",
   },
   cardContentRoot: {
     "&:last-child": {
-      paddingBottom: "16px"
-    }
+      paddingBottom: "16px",
+    },
   },
   offerHeader: {
     "& .MuiCardHeader-avatar": {
-      marginRight: "10px"
-    }
+      marginRight: "10px",
+    },
   },
   avatar: {
-    marginRight: "10px"
+    marginRight: "10px",
   },
   previewImg: {
     height: "0",
-    paddingTop: "56.25%"
+    paddingTop: "56.25%",
   },
-  detailsBtn: {}
+  detailsBtn: {},
 }));
-
 
 export const OfferingPreview = (props) => {
   const dispatch = useDispatch();
@@ -46,12 +51,11 @@ export const OfferingPreview = (props) => {
   let offerInfo = {
     offerId: offer._id,
     offerer: offerer,
-    posting: activePosting
+    posting: activePosting,
   };
 
   let defaultImg = require("../../images/default.jpg");
   let previewImg;
-
 
   useEffect(() => {
     let isMounted = true;
@@ -70,7 +74,6 @@ export const OfferingPreview = (props) => {
       isMounted = false;
     };
   }, [dispatch, offer.userId]);
-
 
   //set previewImage
   if (offeredItems.length > 0) {
@@ -106,17 +109,14 @@ export const OfferingPreview = (props) => {
         <CardActions>
           <Grid container item xs={12} justify={"space-between"}>
             <Grid container item xs={4} alignContent={"center"}>
-              <Button>
-                Details
-              </Button>
+              <Button>Details</Button>
             </Grid>
             <Grid container item xs={8} justify={"flex-end"}>
               <Grid container item xs={4} justify={"flex-end"}>
-                <AcceptIconButton fns={fns}
-                                  offerInfo={offerInfo}/>
+                <AcceptIconButton fns={fns} offerInfo={offerInfo} />
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <DeclineIconButton fns={fns} offerInfo={offerInfo}/>
+                <DeclineIconButton fns={fns} offerInfo={offerInfo} />
               </Grid>
             </Grid>
           </Grid>
@@ -124,8 +124,4 @@ export const OfferingPreview = (props) => {
       </CardContent>
     </Card>
   );
-
 };
-
-
-

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -72,14 +72,13 @@ export const OfferingPreview = (props) => {
   }, [dispatch, offer.userId]);
 
 
+  //set previewImage
   if (offeredItems.length > 0) {
     let firstItem = offeredItems[0];
     previewImg = firstItem.images.length > 0 ? firstItem.images[0] : defaultImg;
   } else {
     previewImg = defaultImg;
   }
-
-  console.log(offer);
 
   return (
     <Card elevation={2} className={classes.cardRoot}>

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -2,14 +2,15 @@ import React, { useEffect, useState } from "react";
 import { getUserByIdAysnc } from "../../redux/actions/userActions";
 import { useDispatch } from "react-redux";
 import { Card, CardActionArea, CardHeader, CardMedia, CardContent, CardActions } from "@material-ui/core";
-import { Link, Button, Grid } from "@material-ui/core";
+import { Link, Button, Grid, IconButton } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import UserAvatar from "../User/UserAvatar";
 import defaultProfile from "../../images/placeholder-profile.png";
+import CheckCircleOutlineIcon from '@material-ui/icons/CheckCircleOutline';import CancelIcon from '@material-ui/icons/Cancel';
+import HighlightOffIcon from '@material-ui/icons/HighlightOff';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   cardRoot: {
-    // maxWidth: "350px"
     minWidth: "300px",
   },
   cardContentRoot: {
@@ -17,22 +18,18 @@ const useStyles = makeStyles(() => ({
       paddingBottom: "16px",
     },
   },
-  acceptBtnContainer: {
-    paddingRight: "5px",
-  },
   acceptBtn: {
-    // backgroundColor: "green",
-    color: "green",
-    borderColor: "green",
+    color: theme.palette.primary.main,
+    borderColor: theme.palette.primary.main,
+  },
+  actionBtnIcon: {
+    fontSize: "1.7rem",
   },
   declineBtn: {
-    // backgroundColor: "red",
-    color: "red",
-    borderColor: "red",
-
+    color: "#b90202",
+    borderColor: "#b90202",
   },
   offerHeader: {
-    // padding: "10px"
     "& .MuiCardHeader-avatar": {
       marginRight: "10px",
     }
@@ -99,47 +96,24 @@ export const OfferingPreview = (props) => {
         title="Tradeforce"
       />
 
-      {/*<CardContent className={classes.cardContentRoot}>*/}
-      {/*  <CardActions>*/}
-      {/*    <Grid container item xs={12} justify={"space-between"}>*/}
-      {/*      <Grid item xs={3}>*/}
-      {/*      <Button >*/}
-      {/*        Details*/}
-      {/*      </Button>*/}
-      {/*      </Grid>*/}
-      {/*      <Grid container item xs={9} justify={"flex-end"}>*/}
-      {/*        <Grid container item xs={4} justify={"flex-end"} className={classes.acceptBtnContainer}>*/}
-      {/*          <Button variant={"contained"} className={classes.acceptBtn}>*/}
-      {/*            Accept*/}
-      {/*          </Button>*/}
-      {/*        </Grid>*/}
-      {/*        <Grid container item xs={4} justify={"flex-end"}>*/}
-      {/*          <Button variant={"contained"} className={classes.declineBtn}>*/}
-      {/*            Decline*/}
-      {/*          </Button>*/}
-      {/*        </Grid>*/}
-      {/*      </Grid>*/}
-      {/*    </Grid>*/}
-      {/*  </CardActions>*/}
-      {/*</CardContent>*/}
       <CardContent className={classes.cardContentRoot}>
         <CardActions>
           <Grid container item xs={12} justify={"space-between"}>
-            <Grid item xs={3}>
+            <Grid container item xs={4} alignContent={"center"}>
               <Button >
                 Details
               </Button>
             </Grid>
-            <Grid container item xs={9} justify={"flex-end"}>
-              <Grid container item xs={4} justify={"flex-end"} className={classes.acceptBtnContainer}>
-                <Button variant={"outlined"} className={classes.acceptBtn}>
-                  Accept
-                </Button>
+            <Grid container item xs={8} justify={"flex-end"}>
+              <Grid container item xs={4} justify={"flex-end"} >
+                <IconButton className={classes.acceptBtn}>
+                  <CheckCircleOutlineIcon className={classes.actionBtnIcon}/>
+                </IconButton>
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <Button variant={"outlined"} className={classes.declineBtn}>
-                  Decline
-                </Button>
+                <IconButton className={classes.declineBtn}>
+                  <HighlightOffIcon className={classes.actionBtnIcon}/>
+                </IconButton>
               </Grid>
             </Grid>
           </Grid>
@@ -148,7 +122,6 @@ export const OfferingPreview = (props) => {
     </Card>
   );
 
-  // return( <img src={offerPreviewImgSrc} alt={"test"}/>)
 };
 
 

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -21,12 +21,15 @@ const useStyles = makeStyles(() => ({
     paddingRight: "5px",
   },
   acceptBtn: {
-    backgroundColor: "green",
-    color: "white",
+    // backgroundColor: "green",
+    color: "green",
+    borderColor: "green",
   },
   declineBtn: {
-    backgroundColor: "red",
-    color: "white",
+    // backgroundColor: "red",
+    color: "red",
+    borderColor: "red",
+
   },
   offerHeader: {
     // padding: "10px"
@@ -96,29 +99,51 @@ export const OfferingPreview = (props) => {
         title="Tradeforce"
       />
 
+      {/*<CardContent className={classes.cardContentRoot}>*/}
+      {/*  <CardActions>*/}
+      {/*    <Grid container item xs={12} justify={"space-between"}>*/}
+      {/*      <Grid item xs={3}>*/}
+      {/*      <Button >*/}
+      {/*        Details*/}
+      {/*      </Button>*/}
+      {/*      </Grid>*/}
+      {/*      <Grid container item xs={9} justify={"flex-end"}>*/}
+      {/*        <Grid container item xs={4} justify={"flex-end"} className={classes.acceptBtnContainer}>*/}
+      {/*          <Button variant={"contained"} className={classes.acceptBtn}>*/}
+      {/*            Accept*/}
+      {/*          </Button>*/}
+      {/*        </Grid>*/}
+      {/*        <Grid container item xs={4} justify={"flex-end"}>*/}
+      {/*          <Button variant={"contained"} className={classes.declineBtn}>*/}
+      {/*            Decline*/}
+      {/*          </Button>*/}
+      {/*        </Grid>*/}
+      {/*      </Grid>*/}
+      {/*    </Grid>*/}
+      {/*  </CardActions>*/}
+      {/*</CardContent>*/}
       <CardContent className={classes.cardContentRoot}>
         <CardActions>
           <Grid container item xs={12} justify={"space-between"}>
             <Grid item xs={3}>
-            <Button >
-              Details
-            </Button>
+              <Button >
+                Details
+              </Button>
             </Grid>
             <Grid container item xs={9} justify={"flex-end"}>
               <Grid container item xs={4} justify={"flex-end"} className={classes.acceptBtnContainer}>
-                <Button variant={"contained"} className={classes.acceptBtn}>
+                <Button variant={"outlined"} className={classes.acceptBtn}>
                   Accept
                 </Button>
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <Button variant={"contained"} className={classes.declineBtn}>
+                <Button variant={"outlined"} className={classes.declineBtn}>
                   Decline
                 </Button>
               </Grid>
             </Grid>
           </Grid>
         </CardActions>
-
       </CardContent>
     </Card>
   );

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -1,37 +1,75 @@
 import React, { useEffect, useState } from "react";
-import { Card, CardActionArea, CardHeader } from "@material-ui/core";
-import { Typography } from "@material-ui/core";
 import { getUserByIdAysnc } from "../../redux/actions/userActions";
 import { useDispatch } from "react-redux";
-import axios from "axios";
+import { Card, CardActionArea, CardHeader, CardMedia, CardActions } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+import UserAvatar from "../User/UserAvatar";
+import defaultProfile from "../../images/placeholder-profile.png";
 
-const BASE_URL = `${process.env.REACT_APP_BASE_URL}`;
-
+const useStyles = makeStyles(() => ({
+  cardRoot: {
+    maxWidth: "350px"
+  },
+  previewImg: {
+    height: "0",
+    paddingTop: "56.25%",
+  },
+}));
 export const OfferingPreview = (props) => {
-  let { offer, index } = props;
   const dispatch = useDispatch();
-  const [offerer, setOfferer] = useState({ } );
+  const [offerer, setOfferer] = useState({});
+  let classes = useStyles();
+  let { offer, index } = props;
+  let { offeredItems } = offer;
+  let defaultImg = require("../../images/default.jpg")
+  let previewImg;
 
-  useEffect( () => {
+
+  useEffect(() => {
     async function getOfferer() {
       let user = await dispatch(getUserByIdAysnc(offer.userId));
       setOfferer(user);
       return user;
     }
     getOfferer();
-  }, [])
+  }, [dispatch, offer.userId]);
 
+  if (offeredItems.length > 0) {
+    let firstItem = offeredItems[0];
+    previewImg = firstItem.images.length > 0 ? firstItem.images[0] : defaultImg;
+  } else {
+    previewImg = defaultImg;
+  }
+
+  console.log(offer);
 
   return (
-    <Card elevation={2}>
-      <CardActionArea >
-        <CardHeader title={`${offerer.userName} has made you an offer`}></CardHeader>
-      </CardActionArea>
-    </Card>
-  )
-}
+    <Card elevation={2} className={classes.cardRoot}>
+      <CardActions disableSpacing>
+        <CardHeader
+          avatar={
+            <UserAvatar
+              isLargeAvatar={false}
+              userProfileImgSrc={
+                offerer.profilePic ? offerer.profilePic : defaultProfile
+              }
+            />
+          }
+          title={`${offerer.userName}`}
+          subheader={"has made you an offer"}
+        />
+      </CardActions>
+      <CardMedia
+        className={classes.previewImg}
+        image={previewImg}
+        title="Tradeforce"
+      />
 
-const mapDispatchToProps = (dispatch) => ({
-  getUser: (userId) => dispatch(getUserByIdAysnc(userId)),
-})
+    </Card>
+  );
+
+  // return( <img src={offerPreviewImgSrc} alt={"test"}/>)
+};
+
+
 

--- a/src/components/Offering/OfferingPreview.js
+++ b/src/components/Offering/OfferingPreview.js
@@ -17,6 +17,17 @@ const useStyles = makeStyles(() => ({
       paddingBottom: "16px",
     },
   },
+  acceptBtnContainer: {
+    paddingRight: "5px",
+  },
+  acceptBtn: {
+    backgroundColor: "green",
+    color: "white",
+  },
+  declineBtn: {
+    backgroundColor: "red",
+    color: "white",
+  },
   offerHeader: {
     // padding: "10px"
     "& .MuiCardHeader-avatar": {
@@ -94,13 +105,13 @@ export const OfferingPreview = (props) => {
             </Button>
             </Grid>
             <Grid container item xs={9} justify={"flex-end"}>
-              <Grid container item xs={4} justify={"flex-end"}>
-                <Button>
+              <Grid container item xs={4} justify={"flex-end"} className={classes.acceptBtnContainer}>
+                <Button variant={"contained"} className={classes.acceptBtn}>
                   Accept
                 </Button>
               </Grid>
               <Grid container item xs={4} justify={"flex-end"}>
-                <Button>
+                <Button variant={"contained"} className={classes.declineBtn}>
                   Decline
                 </Button>
               </Grid>

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -6,7 +6,6 @@ import { OfferingPreview } from "./OfferingPreview";
 
 export const OfferingPreviewList = (props) => {
   let { offerings } = props;
-  console.log(offerings);
 
   return (
     <Grid container alignContent={"center"} justify={"flex-start"}>

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -2,7 +2,6 @@ import React from "react";
 import { Grid } from "@material-ui/core";
 
 import { OfferingPreview } from "./OfferingPreview";
-// import  OfferingPreview  from "./OfferingPreview";
 
 export const OfferingPreviewList = (props) => {
   let { pendingOffers, fns, activePosting } = props;

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -5,15 +5,14 @@ import { OfferingPreview } from "./OfferingPreview";
 // import  OfferingPreview  from "./OfferingPreview";
 
 export const OfferingPreviewList = (props) => {
-  let { offerings } = props;
+  let { offerings, fns } = props;
 
   return (
     <Grid container alignContent={"center"} justify={"flex-start"}>
       {offerings.map((offer, index) => {
         return (
           <Grid item key={index}>
-            <OfferingPreview offer={offer} index={index}/>
-
+            <OfferingPreview offer={offer} index={index} fns={fns}/>
           </Grid>
         );
       })}

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -5,11 +5,11 @@ import { OfferingPreview } from "./OfferingPreview";
 // import  OfferingPreview  from "./OfferingPreview";
 
 export const OfferingPreviewList = (props) => {
-  let { offerings, fns, activePosting } = props;
+  let { pendingOffers, fns, activePosting } = props;
 
   return (
-    <Grid container alignContent={"center"} justify={"start"} spacing={2}>
-      {offerings.map((offer, index) => {
+    <Grid container alignContent={"center"} justify={"flex-start"} spacing={2}>
+      {pendingOffers.map((offer, index) => {
         return (
           <Grid item key={index} >
             <OfferingPreview offer={offer} index={index} fns={fns} activePosting={activePosting}/>

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -5,14 +5,14 @@ import { OfferingPreview } from "./OfferingPreview";
 // import  OfferingPreview  from "./OfferingPreview";
 
 export const OfferingPreviewList = (props) => {
-  let { offerings, fns } = props;
+  let { offerings, fns, activePosting } = props;
 
   return (
     <Grid container alignContent={"center"} justify={"flex-start"}>
       {offerings.map((offer, index) => {
         return (
           <Grid item key={index}>
-            <OfferingPreview offer={offer} index={index} fns={fns}/>
+            <OfferingPreview offer={offer} index={index} fns={fns} activePosting={activePosting}/>
           </Grid>
         );
       })}

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -8,10 +8,10 @@ export const OfferingPreviewList = (props) => {
   let { offerings, fns, activePosting } = props;
 
   return (
-    <Grid container alignContent={"center"} justify={"flex-start"}>
+    <Grid container alignContent={"center"} justify={"start"} spacing={2}>
       {offerings.map((offer, index) => {
         return (
-          <Grid item key={index}>
+          <Grid item key={index} >
             <OfferingPreview offer={offer} index={index} fns={fns} activePosting={activePosting}/>
           </Grid>
         );

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -11,8 +11,13 @@ export const OfferingPreviewList = (props) => {
     <Grid container alignContent={"center"} justify={"flex-start"} spacing={2}>
       {pendingOffers.map((offer, index) => {
         return (
-          <Grid item key={index} >
-            <OfferingPreview offer={offer} index={index} fns={fns} activePosting={activePosting}/>
+          <Grid item key={index}>
+            <OfferingPreview
+              offer={offer}
+              index={index}
+              fns={fns}
+              activePosting={activePosting}
+            />
           </Grid>
         );
       })}

--- a/src/components/Offering/OfferingPreviewList.js
+++ b/src/components/Offering/OfferingPreviewList.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Grid } from "@material-ui/core";
+
+import { OfferingPreview } from "./OfferingPreview";
+// import  OfferingPreview  from "./OfferingPreview";
+
+export const OfferingPreviewList = (props) => {
+  let { offerings } = props;
+  console.log(offerings);
+
+  return (
+    <Grid container alignContent={"center"} justify={"flex-start"}>
+      {offerings.map((offer, index) => {
+        return (
+          <Grid item key={index}>
+            <OfferingPreview offer={offer} index={index}/>
+
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+};

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Grid, Typography, Link, Collapse } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { OfferingPreviewList } from "./OfferingPreviewList";
 import ConfirmationDialog from "../ConfirmationDialog";
-import { acceptOffer } from "../../redux/actions/offeringActions";
+import { acceptOffer, declineOffer } from "../../redux/actions/offeringActions";
 import { getAllPendingOffers } from "./OfferingHelpers";
 
 const useStyles = makeStyles((theme) => ({
@@ -37,8 +37,15 @@ export const OffersReceived = (props) => {
   let [confirmationOpen, setConfirmationOpen] = useState(false);
   let [confirmationType, setConfirmationType] = useState("");
 
-  // offerInfo: {offerId, offerer, posting}
+  /** offerInfo: {offerId, offerer, posting} */
   let [offerInfoToActUpon, setOfferInfoToActUpon] = useState({});
+
+
+  const handleAcceptOffer = async () => {
+    let { offerId } = offerInfoToActUpon;
+    await dispatch(acceptOffer(offerId))
+    handleConfirmationClose();
+  }
 
   const handleConfirmationOpen = (type) => {
     setConfirmationOpen(true);
@@ -51,10 +58,15 @@ export const OffersReceived = (props) => {
     setOfferInfoToActUpon({});
   };
 
-  const handleAcceptOffer = async () => {
+  const handleDeclineOffer = async () => {
     let { offerId } = offerInfoToActUpon;
-    await dispatch(acceptOffer(offerId))
+    await dispatch(declineOffer(offerId));
+    handleConfirmationClose();
   }
+
+  const handleExpand = (index) => {
+    expanded === index ? setExpanded(-1) : setExpanded(index);
+  };
 
   const selectConfirmationToDisplay = () => {
     let {offerer, posting} = offerInfoToActUpon;
@@ -65,10 +77,7 @@ export const OffersReceived = (props) => {
           return (
             <ConfirmationDialog
               open={confirmationOpen}
-              submitAction={ async () => {
-                await handleAcceptOffer();
-                handleConfirmationClose();
-              }}
+              submitAction={handleAcceptOffer}
               submitName={"Accept Offer"}
               dialogMessage={
                 `All other offers for your post "${posting.title}" will be declined. This action cannot be undone.`
@@ -81,7 +90,7 @@ export const OffersReceived = (props) => {
           return (
             <ConfirmationDialog
               open={confirmationOpen}
-              submitAction={null}
+              submitAction={handleDeclineOffer}
               submitName={"Decline Offer"}
               dialogMessage={"This action cannot be undone."}
               dialogTitle={`Are you sure you want to decline ${offerer.userName}'s offer?`}
@@ -93,10 +102,6 @@ export const OffersReceived = (props) => {
       }
     }
     return null;
-  };
-
-  const handleExpand = (index) => {
-    expanded === index ? setExpanded(-1) : setExpanded(index);
   };
 
   const renderAllOfferings = () => {
@@ -144,7 +149,6 @@ export const OffersReceived = (props) => {
   return (
     <Grid
       container
-      // spacing={4}
       justify={"center"}
       alignContent={"flex-start"}
       className={classes.allOffersContainer}

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -40,12 +40,11 @@ export const OffersReceived = (props) => {
   /** offerInfo: {offerId, offerer, posting} */
   let [offerInfoToActUpon, setOfferInfoToActUpon] = useState({});
 
-
   const handleAcceptOffer = async () => {
     let { offerId } = offerInfoToActUpon;
-    await dispatch(acceptOffer(offerId))
+    await dispatch(acceptOffer(offerId));
     handleConfirmationClose();
-  }
+  };
 
   const handleConfirmationOpen = (type) => {
     setConfirmationOpen(true);
@@ -62,14 +61,14 @@ export const OffersReceived = (props) => {
     let { offerId } = offerInfoToActUpon;
     await dispatch(declineOffer(offerId));
     handleConfirmationClose();
-  }
+  };
 
   const handleExpand = (index) => {
     expanded === index ? setExpanded(-1) : setExpanded(index);
   };
 
   const selectConfirmationToDisplay = () => {
-    let {offerer, posting} = offerInfoToActUpon;
+    let { offerer, posting } = offerInfoToActUpon;
 
     if (confirmationOpen) {
       switch (confirmationType) {
@@ -79,9 +78,7 @@ export const OffersReceived = (props) => {
               open={confirmationOpen}
               submitAction={handleAcceptOffer}
               submitName={"Accept Offer"}
-              dialogMessage={
-                `All other offers for your post "${posting.title}" will be declined. This action cannot be undone.`
-              }
+              dialogMessage={`All other offers for your post "${posting.title}" will be declined. This action cannot be undone.`}
               dialogTitle={`Are you sure you want to accept ${offerer.userName}'s offer?`}
               handleClose={handleConfirmationClose}
             />
@@ -111,7 +108,12 @@ export const OffersReceived = (props) => {
       if (pendingOffers.length > 0) {
         return (
           <React.Fragment key={index}>
-            <Grid container key={index} className={classes.postingOffers} spacing={4}>
+            <Grid
+              container
+              key={index}
+              className={classes.postingOffers}
+              spacing={4}
+            >
               <Grid container item xs={12} key={index} justify={"center"}>
                 <Grid item xs={10} className={classes.title}>
                   <Typography className={classes.postingTitle}>
@@ -129,7 +131,7 @@ export const OffersReceived = (props) => {
                   )}
                 </Grid>
               </Grid>
-              <Grid container item xs={12} >
+              <Grid container item xs={12}>
                 <Collapse in={index === expanded}>
                   <OfferingPreviewList
                     pendingOffers={pendingOffers}

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -2,10 +2,11 @@ import React, { useState } from "react";
 import { useDispatch } from "react-redux";
 import { Grid, Typography, Link, Collapse } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+
 import { OfferingPreviewList } from "./OfferingPreviewList";
-import ConfirmationDialog from "../ConfirmationDialog";
 import { acceptOffer, declineOffer } from "../../redux/actions/offeringActions";
 import { getAllPendingOffers } from "./OfferingHelpers";
+import ConfirmationDialog from "../ConfirmationDialog";
 
 const useStyles = makeStyles((theme) => ({
   allOffersContainer: {

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -4,6 +4,7 @@ import { Grid, Typography, Link, Collapse } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { OfferingPreviewList } from "./OfferingPreviewList";
 import ConfirmationDialog from "../ConfirmationDialog";
+import { acceptOffer } from "../../redux/actions/offeringActions";
 
 const useStyles = makeStyles((theme) => ({
   allOffersContainer: {
@@ -50,11 +51,12 @@ export const OffersReceived = (props) => {
   };
 
   const handleAcceptOffer = async () => {
-
+    let { offerId } = offerInfoToActUpon;
+    await dispatch(acceptOffer(offerId))
   }
 
   const selectConfirmationToDisplay = () => {
-    let {offerId, offerer, posting} = offerInfoToActUpon;
+    let {offerer, posting} = offerInfoToActUpon;
 
     if (confirmationOpen) {
       switch (confirmationType) {
@@ -62,7 +64,10 @@ export const OffersReceived = (props) => {
           return (
             <ConfirmationDialog
               open={confirmationOpen}
-              submitAction={null}
+              submitAction={ async () => {
+                await handleAcceptOffer();
+                handleConfirmationClose();
+              }}
               submitName={"Accept Offer"}
               dialogMessage={
                 `All other offers for your post "${posting.title}" will be declined. This action cannot be undone.`
@@ -100,7 +105,7 @@ export const OffersReceived = (props) => {
       if (offerings.length > 0) {
         return (
           <React.Fragment key={index}>
-            <Grid container key={index} className={classes.postingOffers} spacing={1}>
+            <Grid container key={index} className={classes.postingOffers} spacing={4}>
               <Grid container item xs={12} key={index} justify={"center"}>
                 <Grid item xs={10} className={classes.title}>
                   <Typography className={classes.postingTitle}>
@@ -118,7 +123,7 @@ export const OffersReceived = (props) => {
                   )}
                 </Grid>
               </Grid>
-              <Grid item xs={12}>
+              <Grid container item xs={12} >
                 <Collapse in={index === expanded}>
                   <OfferingPreviewList
                     offerings={offerings}

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Grid, Typography, Link, Collapse } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
+import { OfferingPreviewList } from "./OfferingPreviewList";
 
 const useStyles = makeStyles((theme) => ({
   allOffersContainer: {
@@ -56,7 +57,7 @@ export const OffersReceived = (props) => {
             </Grid>
             <Grid item xs={12}>
               <Collapse in={index === expanded}>
-                HI
+                <OfferingPreviewList offerings={offerings}/>
 
               </Collapse>
             </Grid>

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useDispatch } from "react-redux";
 import { Grid, Typography, Link, Collapse } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { OfferingPreviewList } from "./OfferingPreviewList";
@@ -27,11 +28,15 @@ const useStyles = makeStyles((theme) => ({
 
 export const OffersReceived = (props) => {
   let classes = useStyles();
+  let dispatch = useDispatch();
   let { activePostings } = props;
-  let [expanded, setExpanded] = useState(-1);
 
+  let [expanded, setExpanded] = useState(-1);
   let [confirmationOpen, setConfirmationOpen] = useState(false);
   let [confirmationType, setConfirmationType] = useState("");
+
+  // offerInfo: {offerId, offerer, posting}
+  let [offerInfoToActUpon, setOfferInfoToActUpon] = useState({});
 
   const handleConfirmationOpen = (type) => {
     setConfirmationOpen(true);
@@ -41,9 +46,16 @@ export const OffersReceived = (props) => {
   const handleConfirmationClose = () => {
     setConfirmationOpen(false);
     setConfirmationType("");
+    setOfferInfoToActUpon({});
   };
 
+  const handleAcceptOffer = async () => {
+
+  }
+
   const selectConfirmationToDisplay = () => {
+    let {offerId, offerer, posting} = offerInfoToActUpon;
+
     if (confirmationOpen) {
       switch (confirmationType) {
         case "accept":
@@ -53,9 +65,10 @@ export const OffersReceived = (props) => {
               submitAction={null}
               submitName={"Accept Offer"}
               dialogMessage={
-                "All other offers for this post will be declined. This action cannot be undone."
+                `All other offers for your post "${posting.title}" will be declined. This action cannot be undone.`
               }
-              dialogTitle={"Are you sure you want to accept this offer?"}
+              dialogTitle={`Are you sure you want to accept ${offerer.userName}'s offer?`}
+              handleClose={handleConfirmationClose}
             />
           );
         case "decline":
@@ -65,7 +78,8 @@ export const OffersReceived = (props) => {
               submitAction={null}
               submitName={"Decline Offer"}
               dialogMessage={"This action cannot be undone."}
-              dialogTitle={"Are you sure you want to decline this offer?"}
+              dialogTitle={`Are you sure you want to decline ${offerer.userName}'s offer?`}
+              handleClose={handleConfirmationClose}
             />
           );
         default:
@@ -108,7 +122,8 @@ export const OffersReceived = (props) => {
                 <Collapse in={index === expanded}>
                   <OfferingPreviewList
                     offerings={offerings}
-                    fns={{ handleConfirmationOpen, handleConfirmationClose }}
+                    activePosting={activePosting}
+                    fns={{ handleConfirmationOpen, setOfferInfoToActUpon }}
                   />
                 </Collapse>
               </Grid>
@@ -128,7 +143,7 @@ export const OffersReceived = (props) => {
       alignContent={"flex-start"}
       className={classes.allOffersContainer}
     >
-      {confirmationOpen && selectConfirmationToDisplay()}
+      {selectConfirmationToDisplay()}
       {renderAllOfferings()}
     </Grid>
   );

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -5,6 +5,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import { OfferingPreviewList } from "./OfferingPreviewList";
 import ConfirmationDialog from "../ConfirmationDialog";
 import { acceptOffer } from "../../redux/actions/offeringActions";
+import { getAllPendingOffers } from "./OfferingHelpers";
 
 const useStyles = makeStyles((theme) => ({
   allOffersContainer: {
@@ -100,9 +101,9 @@ export const OffersReceived = (props) => {
 
   const renderAllOfferings = () => {
     return activePostings.map((activePosting, index) => {
-      let offerings = activePosting.offerings;
+      let pendingOffers = getAllPendingOffers(activePosting.offerings);
 
-      if (offerings.length > 0) {
+      if (pendingOffers.length > 0) {
         return (
           <React.Fragment key={index}>
             <Grid container key={index} className={classes.postingOffers} spacing={4}>
@@ -112,7 +113,7 @@ export const OffersReceived = (props) => {
                     Posting: {activePosting.title}
                   </Typography>
                   <Typography className={classes.numOffering}>
-                    &nbsp;(Offers: {offerings.length})
+                    &nbsp;(Offers: {pendingOffers.length})
                   </Typography>
                 </Grid>
                 <Grid container item xs={2} justify={"center"}>
@@ -126,7 +127,7 @@ export const OffersReceived = (props) => {
               <Grid container item xs={12} >
                 <Collapse in={index === expanded}>
                   <OfferingPreviewList
-                    offerings={offerings}
+                    pendingOffers={pendingOffers}
                     activePosting={activePosting}
                     fns={{ handleConfirmationOpen, setOfferInfoToActUpon }}
                   />

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -1,37 +1,82 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Grid, Typography, Link, Collapse } from "@material-ui/core";
 import { makeStyles } from "@material-ui/core/styles";
 import { OfferingPreviewList } from "./OfferingPreviewList";
+import ConfirmationDialog from "../ConfirmationDialog";
 
 const useStyles = makeStyles((theme) => ({
   allOffersContainer: {
-    padding:"40px",
-    minHeight: "50vh",
+    padding: "40px",
+    minHeight: "50vh"
   },
   postingOffers: {
-    paddingBottom: "35px",
+    paddingBottom: "35px"
   },
   postingTitle: {
     fontSize: "1.5rem",
-    color: theme.palette.primary.main,
+    color: theme.palette.primary.main
   },
   numOffering: {
     fontSize: "1.5rem",
-    color: theme.palette.primary.main,
+    color: theme.palette.primary.main
   },
   title: {
-    display: "inherit",
-  },
-}))
+    display: "inherit"
+  }
+}));
 
 export const OffersReceived = (props) => {
   let classes = useStyles();
   let { activePostings } = props;
   let [expanded, setExpanded] = useState(-1);
 
+  let [confirmationOpen, setConfirmationOpen] = useState(false);
+  let [confirmationType, setConfirmationType] = useState("");
+
+
+  const handleConfirmationOpen = (type) => {
+    setConfirmationOpen(true);
+    setConfirmationType(type);
+  };
+
+  const handleConfirmationClose = () => {
+    setConfirmationOpen(false);
+    setConfirmationType("");
+  };
+
+  const selectConfirmationToDisplay = () => {
+    if (confirmationOpen) {
+      switch (confirmationType) {
+        case "accept":
+          return (
+            <ConfirmationDialog
+              open={confirmationOpen}
+              submitAction={null}
+              submitName={"Accept Offer"}
+              dialogMessage={"All other offers for this post will be declined. This action cannot be undone."}
+              dialogTitle={"Are you sure you want to accept this offer?"}
+            />
+          );
+        case "decline":
+          return (
+            <ConfirmationDialog
+              open={confirmationOpen}
+              submitAction={null}
+              submitName={"Decline Offer"}
+              dialogMessage={"This action cannot be undone."}
+              dialogTitle={"Are you sure you want to decline this offer?"}
+            />
+          );
+        default:
+          return null;
+      }
+    } return null;
+  };
+
+
   const handleExpand = (index) => {
     expanded === index ? setExpanded(-1) : setExpanded(index);
-  }
+  };
 
   const renderAllOfferings = () => {
     return activePostings.map((activePosting, index) => {
@@ -39,29 +84,33 @@ export const OffersReceived = (props) => {
 
       if (offerings.length > 0) {
         return (
-          <Grid container key={index} className={classes.postingOffers} spacing={1}>
-            <Grid container item xs={12} key={index} justify={"center"}>
-              <Grid item xs={10} className={classes.title}>
-              <Typography className={classes.postingTitle}>
-                Posting: {activePosting.title}
-              </Typography>
-              <Typography className={classes.numOffering}>
-                &nbsp;(Offers: {offerings.length})
-              </Typography>
+          <React.Fragment key={index}>
+            {confirmationOpen && selectConfirmationToDisplay()}
+            <Grid container key={index} className={classes.postingOffers} spacing={1}>
+              <Grid container item xs={12} key={index} justify={"center"}>
+                <Grid item xs={10} className={classes.title}>
+                  <Typography className={classes.postingTitle}>
+                    Posting: {activePosting.title}
+                  </Typography>
+                  <Typography className={classes.numOffering}>
+                    &nbsp;(Offers: {offerings.length})
+                  </Typography>
+                </Grid>
+                <Grid container item xs={2} justify={"center"}>
+                  {expanded === index ?
+                    <Link onClick={() => handleExpand(index)}>(Collapse)</Link> :
+                    <Link onClick={() => handleExpand(index)}> (Expand) </Link>}
+                </Grid>
               </Grid>
-              <Grid container item xs={2} justify={"center"} >
-                { expanded === index ?
-                  <Link onClick={() => handleExpand(index)}>(Collapse)</Link> :
-                  <Link onClick={() => handleExpand(index)}> (Expand) </Link>}
+              <Grid item xs={12}>
+                <Collapse in={index === expanded}>
+                  <OfferingPreviewList offerings={offerings}
+                                       fns={{handleConfirmationOpen, handleConfirmationClose}}
+                  />
+                </Collapse>
               </Grid>
             </Grid>
-            <Grid item xs={12}>
-              <Collapse in={index === expanded}>
-                <OfferingPreviewList offerings={offerings}/>
-
-              </Collapse>
-            </Grid>
-          </Grid>);
+          </React.Fragment>);
       }
       return null;
     });
@@ -70,7 +119,7 @@ export const OffersReceived = (props) => {
 
   return (
     <Grid container
-          // spacing={4}
+      // spacing={4}
           justify={"center"}
           alignContent={"flex-start"}
           className={classes.allOffersContainer}

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -86,13 +86,7 @@ export const OffersReceived = (props) => {
       if (offerings.length > 0) {
         return (
           <React.Fragment key={index}>
-            {/* {confirmationOpen && selectConfirmationToDisplay()} */}
-            <Grid
-              container
-              key={index}
-              className={classes.postingOffers}
-              spacing={1}
-            >
+            <Grid container key={index} className={classes.postingOffers} spacing={1}>
               <Grid container item xs={12} key={index} justify={"center"}>
                 <Grid item xs={10} className={classes.title}>
                   <Typography className={classes.postingTitle}>

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -1,0 +1,80 @@
+import React, { useState } from "react";
+import { Grid, Typography, Link, Collapse } from "@material-ui/core";
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  allOffersContainer: {
+    padding:"40px",
+    minHeight: "50vh",
+  },
+  postingOffers: {
+    paddingBottom: "35px",
+  },
+  postingTitle: {
+    fontSize: "1.5rem",
+    color: theme.palette.primary.main,
+  },
+  numOffering: {
+    fontSize: "1.5rem",
+    color: theme.palette.primary.main,
+  },
+  title: {
+    display: "inherit",
+  },
+}))
+
+export const OffersReceived = (props) => {
+  let classes = useStyles();
+  let { activePostings } = props;
+  let [expanded, setExpanded] = useState(-1);
+
+  const handleExpand = (index) => {
+    expanded === index ? setExpanded(-1) : setExpanded(index);
+  }
+
+  const renderAllOfferings = () => {
+    return activePostings.map((activePosting, index) => {
+      let offerings = activePosting.offerings;
+
+      if (offerings.length > 0) {
+        return (
+          <Grid container key={index} className={classes.postingOffers} spacing={1}>
+            <Grid container item xs={12} key={index} justify={"center"}>
+              <Grid item xs={10} className={classes.title}>
+              <Typography className={classes.postingTitle}>
+                Posting: {activePosting.title}
+              </Typography>
+              <Typography className={classes.numOffering}>
+                &nbsp;(Offers: {offerings.length})
+              </Typography>
+              </Grid>
+              <Grid container item xs={2} justify={"center"} >
+                { expanded === index ?
+                  <Link onClick={() => handleExpand(index)}>(Collapse)</Link> :
+                  <Link onClick={() => handleExpand(index)}> (Expand) </Link>}
+              </Grid>
+            </Grid>
+            <Grid item xs={12}>
+              <Collapse in={index === expanded}>
+                HI
+
+              </Collapse>
+            </Grid>
+          </Grid>);
+      }
+      return null;
+    });
+
+  };
+
+  return (
+    <Grid container
+          // spacing={4}
+          justify={"center"}
+          alignContent={"flex-start"}
+          className={classes.allOffersContainer}
+    >
+      {renderAllOfferings()}
+    </Grid>
+  );
+};

--- a/src/components/Offering/OffersReceived.js
+++ b/src/components/Offering/OffersReceived.js
@@ -7,22 +7,22 @@ import ConfirmationDialog from "../ConfirmationDialog";
 const useStyles = makeStyles((theme) => ({
   allOffersContainer: {
     padding: "40px",
-    minHeight: "50vh"
+    minHeight: "50vh",
   },
   postingOffers: {
-    paddingBottom: "35px"
+    paddingBottom: "35px",
   },
   postingTitle: {
     fontSize: "1.5rem",
-    color: theme.palette.primary.main
+    color: theme.palette.primary.main,
   },
   numOffering: {
     fontSize: "1.5rem",
-    color: theme.palette.primary.main
+    color: theme.palette.primary.main,
   },
   title: {
-    display: "inherit"
-  }
+    display: "inherit",
+  },
 }));
 
 export const OffersReceived = (props) => {
@@ -32,7 +32,6 @@ export const OffersReceived = (props) => {
 
   let [confirmationOpen, setConfirmationOpen] = useState(false);
   let [confirmationType, setConfirmationType] = useState("");
-
 
   const handleConfirmationOpen = (type) => {
     setConfirmationOpen(true);
@@ -53,7 +52,9 @@ export const OffersReceived = (props) => {
               open={confirmationOpen}
               submitAction={null}
               submitName={"Accept Offer"}
-              dialogMessage={"All other offers for this post will be declined. This action cannot be undone."}
+              dialogMessage={
+                "All other offers for this post will be declined. This action cannot be undone."
+              }
               dialogTitle={"Are you sure you want to accept this offer?"}
             />
           );
@@ -70,9 +71,9 @@ export const OffersReceived = (props) => {
         default:
           return null;
       }
-    } return null;
+    }
+    return null;
   };
-
 
   const handleExpand = (index) => {
     expanded === index ? setExpanded(-1) : setExpanded(index);
@@ -85,8 +86,13 @@ export const OffersReceived = (props) => {
       if (offerings.length > 0) {
         return (
           <React.Fragment key={index}>
-            {confirmationOpen && selectConfirmationToDisplay()}
-            <Grid container key={index} className={classes.postingOffers} spacing={1}>
+            {/* {confirmationOpen && selectConfirmationToDisplay()} */}
+            <Grid
+              container
+              key={index}
+              className={classes.postingOffers}
+              spacing={1}
+            >
               <Grid container item xs={12} key={index} justify={"center"}>
                 <Grid item xs={10} className={classes.title}>
                   <Typography className={classes.postingTitle}>
@@ -97,33 +103,38 @@ export const OffersReceived = (props) => {
                   </Typography>
                 </Grid>
                 <Grid container item xs={2} justify={"center"}>
-                  {expanded === index ?
-                    <Link onClick={() => handleExpand(index)}>(Collapse)</Link> :
-                    <Link onClick={() => handleExpand(index)}> (Expand) </Link>}
+                  {expanded === index ? (
+                    <Link onClick={() => handleExpand(index)}>(Collapse)</Link>
+                  ) : (
+                    <Link onClick={() => handleExpand(index)}> (Expand) </Link>
+                  )}
                 </Grid>
               </Grid>
               <Grid item xs={12}>
                 <Collapse in={index === expanded}>
-                  <OfferingPreviewList offerings={offerings}
-                                       fns={{handleConfirmationOpen, handleConfirmationClose}}
+                  <OfferingPreviewList
+                    offerings={offerings}
+                    fns={{ handleConfirmationOpen, handleConfirmationClose }}
                   />
                 </Collapse>
               </Grid>
             </Grid>
-          </React.Fragment>);
+          </React.Fragment>
+        );
       }
       return null;
     });
-
   };
 
   return (
-    <Grid container
+    <Grid
+      container
       // spacing={4}
-          justify={"center"}
-          alignContent={"flex-start"}
-          className={classes.allOffersContainer}
+      justify={"center"}
+      alignContent={"flex-start"}
+      className={classes.allOffersContainer}
     >
+      {confirmationOpen && selectConfirmationToDisplay()}
       {renderAllOfferings()}
     </Grid>
   );

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -29,11 +29,10 @@ const useStyles = (theme) => ({
 });
 
 class UserDetails extends React.Component {
-  //TODO: Change value: 3 back to 0 in state
   constructor(props) {
     super(props);
     this.state = {
-      value: 3
+      value: 0
     };
   }
 

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -44,7 +44,6 @@ class UserDetails extends React.Component {
   render() {
     const { classes, userDetail, currentUser, openReviewModal } = this.props;
     const { activePostings, offersSent } = userDetail;
-    const offersSentArray = offersSent.data;
 
     return (
       <Paper className={classes.root}>
@@ -88,7 +87,7 @@ class UserDetails extends React.Component {
           ) : null}
           {currentUser && userDetail._id === currentUser._id ? (
             <Tab
-              label={<TabLabel value={offersSentArray.length} title={"Offers Sent"}/>}
+              label={<TabLabel value={offersSent.length} title={"Offers Sent"}/>}
               className={classes.tab}
             />
           ) : null}

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -9,28 +9,29 @@ import TabLabel from "./TabLabel";
 import ReviewList from "../Review/ReviewList";
 import ItemPreviewList from "../Item/ItemPreviewList";
 import Button from "@material-ui/core/Button";
+import { calculateTotalNumOffersReceived } from "../Offering/OfferingHelpers";
 
 const useStyles = (theme) => ({
   root: {
-    flexGrow: 1,
+    flexGrow: 1
   },
   tab: {
-    margin: theme.spacing(0, 5),
+    margin: theme.spacing(0, 5)
   },
   reviewButton: {
-    color: theme.palette.primary.main,
+    color: theme.palette.primary.main
   },
   reviewButtonContainer: {
     display: "flex",
-    justifyContent: "flex-end",
-  },
+    justifyContent: "flex-end"
+  }
 });
 
 class UserDetails extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 0,
+      value: 0
     };
   }
 
@@ -40,6 +41,9 @@ class UserDetails extends React.Component {
 
   render() {
     const { classes, userDetail, currentUser, openReviewModal } = this.props;
+    const { activePostings, offersSent } = userDetail;
+    const offersSentArray = offersSent.data;
+
     return (
       <Paper className={classes.root}>
         <Tabs
@@ -70,22 +74,28 @@ class UserDetails extends React.Component {
           />
           <Tab
             label={
-              <TabLabel value={userDetail.reviews.length} title={"Reviews"} />
+              <TabLabel value={userDetail.reviews.length} title={"Reviews"}/>
             }
             className={classes.tab}
           />
           {currentUser && userDetail._id === currentUser._id ? (
-            <Tab
-              label={<TabLabel value={6} title={"Offers"} />}
-              className={classes.tab}
-            />
+            <React.Fragment>
+              <Tab
+                label={<TabLabel value={calculateTotalNumOffersReceived(activePostings)} title={"Offers Received"}/>}
+                className={classes.tab}
+              />
+              <Tab
+                label={<TabLabel value={offersSentArray.length} title={"Offers Sent"}/>}
+                className={classes.tab}
+              />
+            </React.Fragment>
           ) : null}
         </Tabs>
         <TabPanel value={this.state.value} index={0}>
-          <ItemPreviewList items={userDetail.activePostings} sizing={2} />
+          <ItemPreviewList items={userDetail.activePostings} sizing={2}/>
         </TabPanel>
         <TabPanel value={this.state.value} index={1}>
-          <ItemPreviewList items={userDetail.inactivePostings} sizing={2} />
+          <ItemPreviewList items={userDetail.inactivePostings} sizing={2}/>
         </TabPanel>
         <TabPanel value={this.state.value} index={2}>
           {currentUser && userDetail._id !== currentUser._id && (
@@ -105,7 +115,7 @@ class UserDetails extends React.Component {
           />
         </TabPanel>
         <TabPanel value={this.state.value} index={3}>
-          Item Three
+          Hi
         </TabPanel>
       </Paper>
     );

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -10,6 +10,7 @@ import ReviewList from "../Review/ReviewList";
 import ItemPreviewList from "../Item/ItemPreviewList";
 import Button from "@material-ui/core/Button";
 import { calculateTotalNumOffersReceived } from "../Offering/OfferingHelpers";
+import { OffersReceived } from "../Offering/OffersReceived";
 
 const useStyles = (theme) => ({
   root: {
@@ -28,10 +29,11 @@ const useStyles = (theme) => ({
 });
 
 class UserDetails extends React.Component {
+  //TODO: Change value: 3 back to 0 in state
   constructor(props) {
     super(props);
     this.state = {
-      value: 0
+      value: 3
     };
   }
 
@@ -115,7 +117,7 @@ class UserDetails extends React.Component {
           />
         </TabPanel>
         <TabPanel value={this.state.value} index={3}>
-          Hi
+          <OffersReceived activePostings={activePostings} />
         </TabPanel>
       </Paper>
     );

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -9,7 +9,7 @@ import TabLabel from "./TabLabel";
 import ReviewList from "../Review/ReviewList";
 import ItemPreviewList from "../Item/ItemPreviewList";
 import Button from "@material-ui/core/Button";
-import { calculateTotalNumOffersReceived } from "../Offering/OfferingHelpers";
+import { calculateTotalPendingOffersReceived } from "../Offering/OfferingHelpers";
 import { OffersReceived } from "../Offering/OffersReceived";
 
 const useStyles = (theme) => ({
@@ -81,7 +81,8 @@ class UserDetails extends React.Component {
           />
           {currentUser && userDetail._id === currentUser._id ? (
               <Tab
-                label={<TabLabel value={calculateTotalNumOffersReceived(activePostings)} title={"Offers Received"}/>}
+                label={<TabLabel value={calculateTotalPendingOffersReceived(activePostings)}
+                                 title={"Offers Received"}/>}
                 className={classes.tab}
               />
           ) : null}

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -79,16 +79,16 @@ class UserDetails extends React.Component {
             className={classes.tab}
           />
           {currentUser && userDetail._id === currentUser._id ? (
-            <React.Fragment>
               <Tab
                 label={<TabLabel value={calculateTotalNumOffersReceived(activePostings)} title={"Offers Received"}/>}
                 className={classes.tab}
               />
-              <Tab
-                label={<TabLabel value={offersSentArray.length} title={"Offers Sent"}/>}
-                className={classes.tab}
-              />
-            </React.Fragment>
+          ) : null}
+          {currentUser && userDetail._id === currentUser._id ? (
+            <Tab
+              label={<TabLabel value={offersSentArray.length} title={"Offers Sent"}/>}
+              className={classes.tab}
+            />
           ) : null}
         </Tabs>
         <TabPanel value={this.state.value} index={0}>

--- a/src/components/User/UserDetails.js
+++ b/src/components/User/UserDetails.js
@@ -14,25 +14,25 @@ import { OffersReceived } from "../Offering/OffersReceived";
 
 const useStyles = (theme) => ({
   root: {
-    flexGrow: 1
+    flexGrow: 1,
   },
   tab: {
-    margin: theme.spacing(0, 5)
+    margin: theme.spacing(0, 5),
   },
   reviewButton: {
-    color: theme.palette.primary.main
+    color: theme.palette.primary.main,
   },
   reviewButtonContainer: {
     display: "flex",
-    justifyContent: "flex-end"
-  }
+    justifyContent: "flex-end",
+  },
 });
 
 class UserDetails extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 0
+      value: 0,
     };
   }
 
@@ -74,29 +74,35 @@ class UserDetails extends React.Component {
           />
           <Tab
             label={
-              <TabLabel value={userDetail.reviews.length} title={"Reviews"}/>
+              <TabLabel value={userDetail.reviews.length} title={"Reviews"} />
             }
             className={classes.tab}
           />
           {currentUser && userDetail._id === currentUser._id ? (
-              <Tab
-                label={<TabLabel value={calculateTotalPendingOffersReceived(activePostings)}
-                                 title={"Offers Received"}/>}
-                className={classes.tab}
-              />
+            <Tab
+              label={
+                <TabLabel
+                  value={calculateTotalPendingOffersReceived(activePostings)}
+                  title={"Offers Received"}
+                />
+              }
+              className={classes.tab}
+            />
           ) : null}
           {currentUser && userDetail._id === currentUser._id ? (
             <Tab
-              label={<TabLabel value={offersSent.length} title={"Offers Sent"}/>}
+              label={
+                <TabLabel value={offersSent.length} title={"Offers Sent"} />
+              }
               className={classes.tab}
             />
           ) : null}
         </Tabs>
         <TabPanel value={this.state.value} index={0}>
-          <ItemPreviewList items={userDetail.activePostings} sizing={2}/>
+          <ItemPreviewList items={userDetail.activePostings} sizing={2} />
         </TabPanel>
         <TabPanel value={this.state.value} index={1}>
-          <ItemPreviewList items={userDetail.inactivePostings} sizing={2}/>
+          <ItemPreviewList items={userDetail.inactivePostings} sizing={2} />
         </TabPanel>
         <TabPanel value={this.state.value} index={2}>
           {currentUser && userDetail._id !== currentUser._id && (

--- a/src/redux/actions/userActions.js
+++ b/src/redux/actions/userActions.js
@@ -200,7 +200,7 @@ export const authenticateUser = (token) => {
 };
 
 export const getUserByIdAysnc = (userId) => {
-  return async dispatch => {
+  return async (dispatch) => {
     try {
       let response = await axios.get(`${BASE_URL}/${userId}`);
       let user = response.data;
@@ -208,8 +208,8 @@ export const getUserByIdAysnc = (userId) => {
     } catch (e) {
       return dispatch(displayError(e.response.data.message));
     }
-  }
-}
+  };
+};
 
 // Helper functions
 const handleAftermathModalBehaviour = (

--- a/src/redux/actions/userActions.js
+++ b/src/redux/actions/userActions.js
@@ -202,7 +202,7 @@ export const authenticateUser = (token) => {
 export const getUserByIdAysnc = (userId) => {
   return async dispatch => {
     try {
-      let response = await axios.get(`/api/users/${userId}`);
+      let response = await axios.get(`${BASE_URL}/${userId}`);
       let user = response.data;
       return user;
     } catch (e) {

--- a/src/redux/actions/userActions.js
+++ b/src/redux/actions/userActions.js
@@ -199,6 +199,18 @@ export const authenticateUser = (token) => {
   };
 };
 
+export const getUserByIdAysnc = (userId) => {
+  return async dispatch => {
+    try {
+      let response = await axios.get(`/api/users/${userId}`);
+      let user = response.data;
+      return user;
+    } catch (e) {
+      return dispatch(displayError(e.response.data.message));
+    }
+  }
+}
+
 // Helper functions
 const handleAftermathModalBehaviour = (
   dispatch,

--- a/src/redux/constants/snackbarMessageTypes.js
+++ b/src/redux/constants/snackbarMessageTypes.js
@@ -1,12 +1,3 @@
-/* ===== Make Offering Errors ===== */
-export const MAKE_OFFER_AS_UNSIGNED_IN_USER_ERROR =
-  "Please sign in or register before making an offer.";
-export const MAKE_OFFER_NO_COMMENT_AND_NO_ADDEDITEMS_ERROR =
-  "An offer must have either a comment or an item";
-
-/* ===== Make Offering Success ===== */
-export const MAKE_OFFER_SUCCESS = "Offer successfully made";
-
 /* ===== Posting Errors ===== */
 export const ADD_POSTING_ERROR =
   "Something went wrong. Posting was not created";
@@ -64,3 +55,5 @@ export const DECLINE_OFFER_ERROR =
   "Offer could not be declined. Please try again later";
 export const RESCIND_OFFER_ERROR =
   "Offer could not be rescinded. Please try again later";
+export const MAKE_OFFER_AS_UNSIGNED_IN_USER_ERROR =
+  "Please sign in or register before making an offer.";

--- a/src/redux/constants/snackbarMessageTypes.js
+++ b/src/redux/constants/snackbarMessageTypes.js
@@ -1,6 +1,11 @@
 /* ===== Make Offering Errors ===== */
 export const MAKE_OFFER_AS_UNSIGNED_IN_USER_ERROR =
   "Please sign in or register before making an offer.";
+export const MAKE_OFFER_NO_COMMENT_AND_NO_ADDEDITEMS_ERROR =
+  "An offer must have either a comment or an item";
+
+/* ===== Make Offering Success ===== */
+export const MAKE_OFFER_SUCCESS = "Offer successfully made";
 
 /* ===== Posting Errors ===== */
 export const ADD_POSTING_ERROR =


### PR DESCRIPTION
**Offers Received Displays on UserProfile of currentUser**

- Tabs for Offers Received and Offers Sent display dynamic numbers
- Offers Received only display _pending_ offers
- Preview cards for pending offers (received) display on userProfile of current owner
- Accept Offer is implemented with confirmation dialog
- Decline Offer is implemented with confirmation dialog

![image](https://user-images.githubusercontent.com/39810669/88235115-035a4c00-cc2f-11ea-9997-c771e0149529.png)
![image](https://user-images.githubusercontent.com/39810669/88235103-fe959800-cc2e-11ea-9ebb-83491c6408f9.png)

Not Completed in this PR:
- Offer Preview Card's "Details" button functionality is not yet implemented.
- Offer Detail Modal is not yet implemented.
- Offers Sent is not yet implemented.