### PR TITLE
posting previews resize and wrap based on screen

### DIFF
--- a/src/components/Item/ItemPreviewList.js
+++ b/src/components/Item/ItemPreviewList.js
@@ -24,7 +24,7 @@ const ItemPreviewList = (props) => {
     >
       {items.map((item, index) => {
         return (
-          <Grid key={index} item xs={sizing}>
+          <Grid key={index} item xs={12} sm={6} md={3} lg={sizing}>
             <ItemPreview
               _id={item._id}
               title={item.title}


### PR DESCRIPTION
Posting previews on search results and profile page will resize at MUI breakpoints so it doesn't squish on smaller screens