### PR TITLE
Bug: For long portrait images, when image is shrunk, the carousal con…

### DIFF
--- a/src/components/AddOffering/AddItems/ItemImagesPreview.js
+++ b/src/components/AddOffering/AddItems/ItemImagesPreview.js
@@ -20,6 +20,7 @@ const useStyles = (theme) => ({
     overflow: "hidden",
     display: "block",
     objectFit: "contain",
+    width: "80%"
   },
   imgContainer: {
     maxWidth: "100%",

--- a/src/components/AddOffering/AddItems/ItemImagesPreview.js
+++ b/src/components/AddOffering/AddItems/ItemImagesPreview.js
@@ -20,7 +20,7 @@ const useStyles = (theme) => ({
     overflow: "hidden",
     display: "block",
     objectFit: "contain",
-    width: "80%"
+    width: "100%"
   },
   imgContainer: {
     maxWidth: "100%",
@@ -51,7 +51,7 @@ class ItemImagesPreview extends React.Component {
     let { images, classes } = this.props;
     let maxSteps = images.length;
     return (
-      <div>
+      <div style={{ width: "100%" }}>
         <div className={classes.imgContainer}>
           <img
             className={classes.img}

--- a/src/components/AddOffering/AddItems/ItemImagesPreview.js
+++ b/src/components/AddOffering/AddItems/ItemImagesPreview.js
@@ -20,7 +20,7 @@ const useStyles = (theme) => ({
     overflow: "hidden",
     display: "block",
     objectFit: "contain",
-    width: "100%"
+    width: "100%",
   },
   imgContainer: {
     maxWidth: "100%",


### PR DESCRIPTION
When shrinking certain long images, the display container spills over the modal, making the "Next"/"Prev" buttons for image preview in detailsModal inaccessible to the user. (Fixed)

Before:
![image](https://user-images.githubusercontent.com/39810669/89250867-8f268d80-d5ca-11ea-9bb9-b206d24bc29d.png)

After:
![image](https://user-images.githubusercontent.com/39810669/89251013-ddd42780-d5ca-11ea-9376-085622ebbb5c.png)

-------------------------------------------------------------------------------------------------------------------------------------------

**Notes**
- Side effect: The width of the carousal is no longer consistent across images 
- For testing purposes, this is the image that caused this problem:
![xks1ruA](https://user-images.githubusercontent.com/39810669/89251113-15db6a80-d5cb-11ea-8651-7316e25cb754.jpg)
