### PR TITLE
use posting location as default for previews

### DIFF
--- a/src/components/Item/ItemHeader.js
+++ b/src/components/Item/ItemHeader.js
@@ -32,8 +32,12 @@ const ItemHeader = (props) => {
   let { date, title, location } = itemDetail;
 
   const getUpdatedLocation = async () => {
-    const user = await props.dispatch(getUserByIdAsync(itemDetail.ownerId));
-    setLoc(user.location.location);
+    if (location && location.location) {
+      setLoc(location.location);
+    } else {
+      const user = await props.dispatch(getUserByIdAsync(itemDetail.ownerId));
+      setLoc(user.location.location);
+    }
   };
 
   useEffect(() => {

--- a/src/components/Item/ItemPreview.js
+++ b/src/components/Item/ItemPreview.js
@@ -27,19 +27,16 @@ const useStyles = makeStyles(() => ({
 }));
 
 const ItemPreview = ({
-  _id,
-  title,
-  date,
-  images,
-  ownerId,
   clearOldItemDetails,
   getUserByIdAsync,
   currentUser,
+  item,
 }) => {
   const classes = useStyles();
   const history = useHistory();
   const [distanceMsg, setDistanceMsg] = useState("");
   const [locationMsg, setLocationMsg] = useState("");
+  const { _id, title, date, images, ownerId, location } = item;
 
   const getDistance = (lat1, lat2, lon1, lon2, unit) => {
     if (lat1 === lat2 && lon1 === lon2) {
@@ -69,26 +66,41 @@ const ItemPreview = ({
   };
 
   const updateDistance = async () => {
-    try {
-      if (ownerId) {
-        let user = await getUserByIdAsync(ownerId);
+    if (location && location.lat && location.lon) {
+      const dist = Math.floor(
+        getDistance(
+          currentUser.user.location.lat,
+          location.lat,
+          currentUser.user.location.lon,
+          location.lon,
+          "K"
+        )
+      );
+      setDistanceMsg(`About ${dist} km away`);
+      setLocationMsg(location.location);
+      return dist;
+    } else {
+      try {
+        if (ownerId) {
+          let user = await getUserByIdAsync(ownerId);
 
-        const dist = Math.floor(
-          getDistance(
-            currentUser.user.location.lat,
-            user.location.lat,
-            currentUser.user.location.lon,
-            user.location.lon,
-            "K"
-          )
-        );
-        setDistanceMsg(`About ${dist} km away`);
-        setLocationMsg(user.location.location);
-        return dist;
+          const dist = Math.floor(
+            getDistance(
+              currentUser.user.location.lat,
+              user.location.lat,
+              currentUser.user.location.lon,
+              user.location.lon,
+              "K"
+            )
+          );
+          setDistanceMsg(`About ${dist} km away`);
+          setLocationMsg(user.location.location);
+          return dist;
+        }
+      } catch (err) {
+        setDistanceMsg("");
+        setLocationMsg("");
       }
-    } catch (err) {
-      setDistanceMsg("");
-      setLocationMsg("");
     }
   };
 
@@ -154,7 +166,7 @@ const ItemPreview = ({
               ? images[0]
               : require("../../images/default.jpg")
           }
-          title="Tradeforce"
+          title={`Preview of ${title || "Untitled Posting"}`}
         />
         <CardContent>
           <Grid container spacing={2}>

--- a/src/components/Item/ItemPreviewList.js
+++ b/src/components/Item/ItemPreviewList.js
@@ -24,13 +24,7 @@ const ItemPreviewList = (props) => {
       {items.map((item, index) => {
         return (
           <Grid key={index} item xs={12} sm={6} md={3} lg={sizing}>
-            <ItemPreview
-              _id={item._id}
-              title={item.title}
-              date={item.date}
-              images={item.images}
-              ownerId={item.ownerId}
-            />
+            <ItemPreview item={item} />
           </Grid>
         );
       })}


### PR DESCRIPTION
Use posting's location to generate the location information on the preview cards as a default. This addresses the issue of React complaints when a user clicks into a posting details before the axios calls to get the posting's owner object is completed. If posting location is not available, will attempt to get location information from posting owner through axios call.